### PR TITLE
fix(release): publish versioned packages after release PR

### DIFF
--- a/.changeset/publish-versioned-packages.md
+++ b/.changeset/publish-versioned-packages.md
@@ -1,0 +1,5 @@
+---
+"@icebreakers/monorepo": patch
+---
+
+修复 Version Packages PR 合并后正式发布被错误跳过的问题，确保已更新版本但尚未发布到 npm 的包会继续执行发布。

--- a/packages/monorepo/src/commands/release.ts
+++ b/packages/monorepo/src/commands/release.ts
@@ -85,12 +85,6 @@ export async function releaseStable(options: ReleaseOptions) {
   run('pnpm', ['run', 'build'], options)
   run('pnpm', ['run', 'lint'], options)
   run('pnpm', ['run', 'test'], options)
-
-  if (!await hasPendingChangesets(options.cwd)) {
-    return
-  }
-
-  run('pnpm', ['exec', 'changeset', 'version'], options)
   run('pnpm', ['exec', 'changeset', 'publish'], options)
 }
 

--- a/packages/monorepo/test/commands/release.test.ts
+++ b/packages/monorepo/test/commands/release.test.ts
@@ -54,9 +54,8 @@ afterEach(async () => {
 })
 
 describe('release commands', () => {
-  it('runs the stable release sequence on main', async () => {
+  it('publishes packages versioned by the merged release pull request', async () => {
     const cwd = await createTempWorkspace()
-    await writePendingChangeset(cwd)
     const { calls, spawn } = createSpawnMock()
 
     await releaseStable({ branch: 'main', cwd, spawn: spawn as never })
@@ -65,21 +64,7 @@ describe('release commands', () => {
       { command: 'pnpm', args: ['run', 'build'] },
       { command: 'pnpm', args: ['run', 'lint'] },
       { command: 'pnpm', args: ['run', 'test'] },
-      { command: 'pnpm', args: ['exec', 'changeset', 'version'] },
       { command: 'pnpm', args: ['exec', 'changeset', 'publish'] },
-    ])
-  })
-
-  it('skips stable publish when there are no pending changesets', async () => {
-    const cwd = await createTempWorkspace()
-    const { calls, spawn } = createSpawnMock()
-
-    await releaseStable({ branch: 'main', cwd, spawn: spawn as never })
-
-    expect(calls).toEqual([
-      { command: 'pnpm', args: ['run', 'build'] },
-      { command: 'pnpm', args: ['run', 'lint'] },
-      { command: 'pnpm', args: ['run', 'test'] },
     ])
   })
 


### PR DESCRIPTION
## 根因

PR #785 合并的是 Changesets 生成的 Version Packages PR。合并后，待发布包的版本已经写入 `package.json`，并且原始 `.changeset/*.md` 按预期被删除。

此前为兼容 Changesets v3 增加的 stable 发布门禁把“没有 changeset 文件”判断为“不需要发布”，导致 `repo release stable` 在执行 `changeset publish` 前直接返回。Actions run 31659535576 因此以 0 退出，但 npm 上仍停留在旧版本，同时 `changesets/action` 报告无法读取 `CHANGESETS_OUTPUT`。

## 修复

- stable 发布不再检查待处理 changeset 文件
- stable 发布不再重复执行 `changeset version`，只发布 Version Packages PR 已固化的版本
- 回归测试覆盖“没有 changeset 文件时仍发布已版本化包”
- 添加 `@icebreakers/monorepo` patch changeset；按 linked 配置会联动 `repoctl`，无需联动 `create-icebreaker`

## 验证

- `pnpm build`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm tsd`
- `pnpm test`（64 files / 233 tests）
- `pnpm exec vitest run packages/monorepo/test/commands/release.test.ts`（7 tests）
- `pnpm exec changeset status --output ...`（`@icebreakers/monorepo` 5.0.4、`repoctl` 5.0.4）

仓库中不存在 skill 推荐的 `scripts/check-create-weapp-vite-changeset.ts` 和 `scripts/check-catalog-changeset.ts`，因此这两条未执行。
