### PR TITLE
fix(ci): add unpublished version recovery

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,23 @@ on:
       - rc
       - next
   workflow_dispatch:
+    inputs:
+      mode:
+        description: Release operation
+        required: true
+        default: changesets
+        type: choice
+        options:
+          - changesets
+          - publish-unpublished
+      package:
+        description: Package used to verify an unpublished-version recovery
+        required: false
+        type: string
+      version:
+        description: Version used to verify an unpublished-version recovery
+        required: false
+        type: string
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 env:
@@ -44,6 +61,7 @@ jobs:
         run: pnpm run tooling:build
 
       - name: Create Release Pull Request or Publish to npm
+        if: github.event_name != 'workflow_dispatch' || inputs.mode == 'changesets'
         id: changesets
         uses: changesets/action@v2.0.0
         with:
@@ -58,13 +76,51 @@ jobs:
           # https://github.com/changesets/changesets/pull/1659
           NPM_CONFIG_PROVENANCE: true
 
+      - name: Validate unpublished-version recovery
+        if: github.event_name == 'workflow_dispatch' && inputs.mode == 'publish-unpublished'
+        shell: bash
+        env:
+          RECOVERY_PACKAGE: ${{ inputs.package }}
+          RECOVERY_VERSION: ${{ inputs.version }}
+        run: |
+          if [[ -z "$RECOVERY_PACKAGE" || -z "$RECOVERY_VERSION" ]]; then
+            echo "package and version are required for publish-unpublished" >&2
+            exit 1
+          fi
+          actual_version="$(pnpm --filter "$RECOVERY_PACKAGE" exec node -p "require('./package.json').version")"
+          if [[ "$actual_version" != "$RECOVERY_VERSION" ]]; then
+            echo "Expected $RECOVERY_PACKAGE@$RECOVERY_VERSION on main, found $actual_version" >&2
+            exit 1
+          fi
+
+      - name: Publish unpublished versions to npm
+        if: github.event_name == 'workflow_dispatch' && inputs.mode == 'publish-unpublished'
+        run: pnpm exec repo release stable
+        env:
+          npm_config_registry: https://registry.npmjs.org
+          NPM_CONFIG_PROVENANCE: true
+
+      - name: Verify recovered npm version
+        if: github.event_name == 'workflow_dispatch' && inputs.mode == 'publish-unpublished'
+        shell: bash
+        env:
+          RECOVERY_PACKAGE: ${{ inputs.package }}
+          RECOVERY_VERSION: ${{ inputs.version }}
+        run: |
+          published_version="$(npm view "$RECOVERY_PACKAGE@$RECOVERY_VERSION" version)"
+          test "$published_version" = "$RECOVERY_VERSION"
+
+      - name: Push recovered release tags
+        if: github.event_name == 'workflow_dispatch' && inputs.mode == 'publish-unpublished'
+        run: git push origin --follow-tags
+
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v7
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   prerelease:
-    if: github.ref_name != 'main'
+    if: github.event_name == 'push' && github.ref_name != 'main'
     name: Prerelease
     runs-on: ubuntu-latest
     steps:

--- a/packages/monorepo/test/commands/release-workflow.test.ts
+++ b/packages/monorepo/test/commands/release-workflow.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { rootDir } from '@/constants'
+import fs from '@/utils/fs'
+
+describe('release workflow', () => {
+  it('can recover versioned packages without consuming pending changesets', async () => {
+    const workflow = await fs.readFile(`${rootDir}/.github/workflows/release.yml`, 'utf8')
+
+    expect(workflow).toContain('- publish-unpublished')
+    expect(workflow).toContain(`inputs.mode == 'changesets'`)
+    expect(workflow).toContain('Validate unpublished-version recovery')
+    expect(workflow).toContain('run: pnpm exec repo release stable')
+    expect(workflow).toContain('npm view \"$RECOVERY_PACKAGE@$RECOVERY_VERSION\" version')
+    expect(workflow).toContain('git push origin --follow-tags')
+  })
+
+  it('does not run prerelease publishing for manual recovery dispatches', async () => {
+    const workflow = await fs.readFile(`${rootDir}/.github/workflows/release.yml`, 'utf8')
+
+    expect(workflow).toContain('if: github.event_name == \'push\' && github.ref_name != \'main\'')
+  })
+})


### PR DESCRIPTION
## 根因

`main` 当前已经包含 PR #785 写入的正式版本：

- `@icebreakers/monorepo@5.0.3`
- `repoctl@5.0.3`
- `@icebreakers/monorepo-templates@1.0.15`
- `create-icebreaker@1.0.15`
- `create-repoctl@0.0.13`

这些版本没有发布到 npm。PR #792 合并后，`main` 又存在用于后续 5.0.4 的 changeset，因此 Changesets action 只会创建/更新版本 PR #793，不会调用 publish command。直接合并 #793 会跳过需要恢复的 5.0.3 等版本。

## 修复

- 为 Release workflow 增加显式的 `publish-unpublished` 手工恢复模式
- 要求输入包名和预期版本，并验证 `main` 中版本完全匹配后才允许发布
- 恢复模式绕过 Changesets 版本 PR 判定，直接发布当前 workspace 中 npm 尚不存在的版本
- 发布后从 npm 精确验证目标版本，并推送 Changesets 创建的 release tags
- 手工恢复不会误触发 prerelease job
- 添加 workflow 结构回归测试

## 恢复顺序

1. 合并本 PR
2. 手工触发 Release workflow：`mode=publish-unpublished`、`package=@icebreakers/monorepo`、`version=5.0.3`
3. 核对上述五个遗漏版本均已进入 npm
4. 保留并最后处理 #793，作为独立的 5.0.4 修复版本

本 PR 不新增或消费 changeset，因此不会更新 #793，也不会改变任何包版本。

## 验证

- `actionlint .github/workflows/release.yml`
- YAML parser 校验
- `pnpm build`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm tsd`
- `pnpm test`（65 files / 235 tests）
- `pnpm exec vitest run packages/monorepo/test/commands/release-workflow.test.ts packages/monorepo/test/commands/release.test.ts`（9 tests）
