### PR TITLE
fix(repoctl): use GitHub Actions token for release CI

### DIFF
--- a/.changeset/release-ci-token.md
+++ b/.changeset/release-ci-token.md
@@ -1,0 +1,6 @@
+---
+"@icebreakers/monorepo": patch
+"@icebreakers/monorepo-templates": patch
+---
+
+修复 release CI 未向 repoctl 注入 GitHub Actions 原生的 `github.token`，导致 Release PR、tag 和 GitHub Release 编排无法调用 GitHub API。

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,7 @@ jobs:
 
       - name: Run repo release CI
         env:
+          GITHUB_TOKEN: ${{ github.token }}
           REPO_RELEASE_MODE: ${{ inputs.mode || 'auto' }}
           REPO_RELEASE_PACKAGE: ${{ inputs.package }}
           REPO_RELEASE_VERSION: ${{ inputs.version }}

--- a/packages/monorepo/test/commands/release-workflow.test.ts
+++ b/packages/monorepo/test/commands/release-workflow.test.ts
@@ -10,6 +10,8 @@ describe('release workflow', () => {
     expect(workflow).toContain('- publish-unpublished')
     expect(workflow).toContain('REPO_RELEASE_MODE: $' + '{{ inputs.mode || \'auto\' }}')
     expect(workflow).toContain('run: pnpm exec repo release ci')
+    expect(workflow).toContain('GITHUB_TOKEN: $' + '{{ github.token }}')
+    expect(workflow).not.toContain('GITHUB_TOKEN: $' + '{{ secrets.GITHUB_TOKEN }}')
     expect(workflow).toContain('contents: write')
     expect(workflow).toContain('pull-requests: write')
     expect(workflow).toContain('id-token: write')


### PR DESCRIPTION
## 问题
Release workflow 调用 `repo release ci` 时，GitHub API 客户端只读取 `GITHUB_TOKEN` 环境变量，但 workflow 没有注入令牌，导致 Release PR 编排失败。

## 修复
- 将 Actions 自动提供的 `${{ github.token }}` 映射到 CLI 使用的 `GITHUB_TOKEN`。
- 测试锁定 runtime token 契约，并禁止回退到 `secrets.GITHUB_TOKEN`。
- 增加中文 changeset。

## 验证
- `pnpm build`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm tsd`
- `pnpm test`
- release workflow/GitHub 定向测试