### PR TITLE
fix(repoctl): isolate release tests from Actions token

### DIFF
--- a/.changeset/release-test-isolation.md
+++ b/.changeset/release-test-isolation.md
@@ -1,0 +1,5 @@
+---
+"@icebreakers/monorepo": patch
+---
+
+修复 release CI 在注入 GitHub Actions token 后，单元测试继承运行时环境导致发布流程误报失败的问题。

--- a/packages/monorepo/test/commands/release-github.test.ts
+++ b/packages/monorepo/test/commands/release-github.test.ts
@@ -58,7 +58,9 @@ describe('GitHub release client', () => {
   })
 
   it('fails with an actionable error when token is missing', async () => {
-    const client = new GitHubClient({ repository: 'acme/repo', fetch: vi.fn() })
+    // The release workflow exports GITHUB_TOKEN for the whole CLI process.
+    // Override it explicitly so this test remains isolated from CI runtime state.
+    const client = new GitHubClient({ token: '', repository: 'acme/repo', fetch: vi.fn() })
 
     await expect(client.ensureRelease({ tag: 'repo@1.0.0', target: 'abc123' })).rejects.toMatchObject({
       message: expect.stringContaining('GITHUB_TOKEN'),


### PR DESCRIPTION
## 根因
Release workflow 会为 `pnpm exec repo release ci` 注入 Actions runtime 的 `GITHUB_TOKEN`。完整测试在同一进程中执行时，缺 token 用例继承了这个环境变量，未能触发预期诊断，反而调用了未配置的 mock fetch。

## 修复
- 缺 token 用例显式传入空 token，隔离 CI runtime 环境。
- 增加中文 changeset。

## 验证
- `GITHUB_TOKEN=ci-runtime-token pnpm test`：251 tests passed
- `pnpm build`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm tsd`

关联失败运行：31777426161（PR #800 合并后的 release workflow）