### PR TITLE
fix(test): remove Vitest native config warnings

### DIFF
--- a/.changeset/vitest-native-config.md
+++ b/.changeset/vitest-native-config.md
@@ -1,0 +1,5 @@
+---
+"@icebreakers/monorepo-templates": patch
+---
+
+修复模板 Vitest 配置在 Vite 原生配置加载器下的路径和扩展名兼容性警告。

--- a/packages/create-icebreaker/vitest.config.ts
+++ b/packages/create-icebreaker/vitest.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
     alias: [
       {
         find: '@icebreakers/monorepo-templates',
-        replacement: path.resolve(__dirname, '../monorepo-templates/src/index.ts'),
+        replacement: path.resolve(import.meta.dirname, '../monorepo-templates/src/index.ts'),
       },
     ],
     passWithNoTests: true,

--- a/packages/monorepo/vitest.config.ts
+++ b/packages/monorepo/vitest.config.ts
@@ -18,11 +18,11 @@ const config = defineProject(mergeConfig(
       alias: [
         {
           find: '@',
-          replacement: path.resolve(__dirname, './src'),
+          replacement: path.resolve(import.meta.dirname, './src'),
         },
         {
           find: '@icebreakers/monorepo-templates',
-          replacement: path.resolve(__dirname, '../monorepo-templates/src/index.ts'),
+          replacement: path.resolve(import.meta.dirname, '../monorepo-templates/src/index.ts'),
         },
       ],
     },

--- a/templates/server/vitest.config.ts
+++ b/templates/server/vitest.config.ts
@@ -1,16 +1,13 @@
 import path from 'node:path'
-import { fileURLToPath } from 'node:url'
 import { defineVitestProjectConfig } from 'repoctl/tooling'
 import { defineProject } from 'vitest/config'
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 export default defineProject(await defineVitestProjectConfig({
   options: {
     alias: [
       {
         find: '@',
-        replacement: path.resolve(__dirname, './src'),
+        replacement: path.resolve(import.meta.dirname, './src'),
       },
     ],
   },

--- a/templates/tsdown/vitest.config.ts
+++ b/templates/tsdown/vitest.config.ts
@@ -1,16 +1,13 @@
 import path from 'node:path'
-import { fileURLToPath } from 'node:url'
 import { defineVitestProjectConfig } from 'repoctl/tooling'
 import { defineProject } from 'vitest/config'
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 export default defineProject(await defineVitestProjectConfig({
   options: {
     alias: [
       {
         find: '@',
-        replacement: path.resolve(__dirname, './src'),
+        replacement: path.resolve(import.meta.dirname, './src'),
       },
     ],
   },

--- a/templates/vue-lib/vitest.config.ts
+++ b/templates/vue-lib/vitest.config.ts
@@ -1,7 +1,7 @@
 import Vue from '@vitejs/plugin-vue'
 import { defineVitestProjectConfig } from 'repoctl/tooling'
 import { mergeConfig } from 'vitest/config'
-import { sharedConfig } from './vite.shared.config'
+import { sharedConfig } from './vite.shared.config.ts'
 
 export default mergeConfig(sharedConfig, {
   ...await defineVitestProjectConfig({


### PR DESCRIPTION
## Summary

修复 Vitest 在 Vite 原生配置加载器下输出兼容性警告的问题。

- 使用 `import.meta.dirname` 替换项目和模板配置中的 `__dirname`
- 为 vue-lib 的共享 Vite 配置导入补充 `.ts` 扩展名
- 新增模板 changeset，确保修复随模板版本发布

## Verification

- `pnpm vitest run`：68 个测试文件、262 个测试通过
- `pnpm lint`
- `pnpm typecheck`