### PR TITLE
feat(repoctl): link release versions to npm

### DIFF
--- a/.changeset/release-npm-links.md
+++ b/.changeset/release-npm-links.md
@@ -1,0 +1,5 @@
+---
+"@icebreakers/monorepo": patch
+---
+
+在 Release Note 中显示包的升级前后版本，并为已发布版本补充 npm 链接。

--- a/packages/monorepo/src/commands/release/body.ts
+++ b/packages/monorepo/src/commands/release/body.ts
@@ -5,6 +5,7 @@ import path from 'pathe'
 import { getWorkspacePackages } from '../../core/workspace'
 import { buildEntries } from './notes/entries'
 import {
+  buildNpmPackageUrl,
   buildPackageCompareUrl,
   parseIntentPackages,
   parseIntentSummary,
@@ -17,12 +18,15 @@ import { capture } from './shared'
 interface PackageJsonVersion {
   name?: unknown
   version?: unknown
+  private?: unknown
 }
 
 interface PackageRelease {
   name: string
   version: string
   previousVersion?: string
+  npmUrl?: string
+  private?: boolean
   content: string
 }
 
@@ -108,6 +112,22 @@ export async function readWorkspaceVersions(cwd: string) {
   return versions
 }
 
+function buildReleasePackage(release: PackageRelease) {
+  const packageLinks: { npmUrl?: string, previousNpmUrl?: string } = {}
+  if (!release.private) {
+    packageLinks.npmUrl = release.npmUrl ?? buildNpmPackageUrl(release.name, release.version)
+    if (release.previousVersion) {
+      packageLinks.previousNpmUrl = buildNpmPackageUrl(release.name, release.previousVersion)
+    }
+  }
+  return {
+    name: release.name,
+    version: release.version,
+    ...(release.previousVersion ? { previousVersion: release.previousVersion } : {}),
+    ...packageLinks,
+  }
+}
+
 export async function buildReleaseNoteDocument(
   cwd: string,
   previousVersions?: Map<string, string>,
@@ -134,6 +154,9 @@ export async function buildReleaseNoteDocument(
       const previousVersion = previousVersions?.get(manifest.name) || release.previousVersion
       releases.push({
         ...release,
+        ...(manifest.private === true
+          ? { private: true }
+          : { npmUrl: buildNpmPackageUrl(manifest.name, manifest.version) }),
         ...(previousVersion ? { previousVersion } : {}),
       })
     }
@@ -149,11 +172,7 @@ export async function buildReleaseNoteDocument(
     .filter((url): url is string => Boolean(url))
 
   return {
-    packages: releases.map(release => ({
-      name: release.name,
-      version: release.version,
-      ...(release.previousVersion ? { previousVersion: release.previousVersion } : {}),
-    })),
+    packages: releases.map(buildReleasePackage),
     entries,
     contributors,
     compareUrls,

--- a/packages/monorepo/src/commands/release/notes/entries.ts
+++ b/packages/monorepo/src/commands/release/notes/entries.ts
@@ -159,6 +159,7 @@ export function buildEntries(release: PackageReleaseSource, commits: ReleaseComm
     return [{
       packageName: release.name,
       version: release.version,
+      ...(release.npmUrl ? { npmUrl: release.npmUrl } : {}),
       category: classifyChange(item.heading, summary, entryCommits),
       summary,
       commits: entryCommits,

--- a/packages/monorepo/src/commands/release/notes/model.ts
+++ b/packages/monorepo/src/commands/release/notes/model.ts
@@ -22,6 +22,7 @@ export interface ReleaseBodyMetadata {
 export interface ReleaseNoteEntry {
   packageName: string
   version: string
+  npmUrl?: string
   category: ReleaseCategory
   summary: string
   commits: ReleaseCommit[]
@@ -30,8 +31,16 @@ export interface ReleaseNoteEntry {
   authors: string[]
 }
 
+export interface ReleaseNotePackage {
+  name: string
+  version: string
+  previousVersion?: string
+  npmUrl?: string
+  previousNpmUrl?: string
+}
+
 export interface ReleaseNoteDocument {
-  packages: Array<{ name: string, version: string, previousVersion?: string }>
+  packages: ReleaseNotePackage[]
   entries: ReleaseNoteEntry[]
   contributors: string[]
   compareUrls: string[]
@@ -41,6 +50,7 @@ export interface PackageReleaseSource {
   name: string
   version: string
   previousVersion?: string
+  npmUrl?: string
   content: string
 }
 
@@ -143,4 +153,9 @@ export function buildPackageCompareUrl(release: PackageReleaseSource, metadata: 
   const previousTag = encodeURIComponent([release.name, release.previousVersion].join('@'))
   const currentTag = encodeURIComponent([release.name, release.version].join('@'))
   return [serverUrl, metadata.repository, 'compare', `${previousTag}...${currentTag}`].join('/')
+}
+
+export function buildNpmPackageUrl(name: string, version: string) {
+  const packagePath = name.startsWith('@') ? name : encodeURIComponent(name)
+  return `https://www.npmjs.com/package/${packagePath}/v/${encodeURIComponent(version)}`
 }

--- a/packages/monorepo/src/commands/release/notes/render.ts
+++ b/packages/monorepo/src/commands/release/notes/render.ts
@@ -20,7 +20,10 @@ function formatReferenceLinks(entry: ReleaseNoteEntry, metadata: ReleaseBodyMeta
 }
 
 function formatEntry(entry: ReleaseNoteEntry, metadata: ReleaseBodyMetadata) {
-  return `- **${entry.packageName}**: ${entry.summary}${formatReferenceLinks(entry, metadata)}`
+  const packageLabel = entry.npmUrl
+    ? `[${entry.packageName}@${entry.version}](${entry.npmUrl})`
+    : `${entry.packageName}@${entry.version}`
+  return `- **${packageLabel}**: ${entry.summary}${formatReferenceLinks(entry, metadata)}`
 }
 
 function formatCategoryEntries(
@@ -54,6 +57,10 @@ function formatContributors(contributors: string[]) {
     : []
 }
 
+function formatVersion(version: string, npmUrl?: string) {
+  return npmUrl ? `[\`${version}\`](${npmUrl})` : `\`${version}\``
+}
+
 function formatPackages(packages: ReleaseNoteDocument['packages']) {
   if (!packages.length) {
     return []
@@ -61,9 +68,13 @@ function formatPackages(packages: ReleaseNoteDocument['packages']) {
   return [
     '## Packages',
     '',
-    '| Package | Version |',
-    '| --- | --- |',
-    ...packages.map(pkg => `| \`${pkg.name}\` | \`${pkg.version}\` |`),
+    '| Package | From | To |',
+    '| --- | --- | --- |',
+    ...packages.map((pkg) => {
+      const previous = pkg.previousVersion ? formatVersion(pkg.previousVersion, pkg.previousNpmUrl) : '—'
+      const current = formatVersion(pkg.version, pkg.npmUrl)
+      return `| \`${pkg.name}\` | ${previous} | ${current} |`
+    }),
   ]
 }
 

--- a/packages/monorepo/test/commands/release-body.test.ts
+++ b/packages/monorepo/test/commands/release-body.test.ts
@@ -53,13 +53,13 @@ describe('release pull request body', () => {
       '',
       '## 🚀 Features',
       '',
-      '- **@acme/demo**: 增加新的发布能力。',
+      '- **[@acme/demo@2.0.0](https://www.npmjs.com/package/@acme/demo/v/2.0.0)**: 增加新的发布能力。',
       '',
       '## Packages',
       '',
-      '| Package | Version |',
-      '| --- | --- |',
-      '| `@acme/demo` | `2.0.0` |',
+      '| Package | From | To |',
+      '| --- | --- | --- |',
+      '| `@acme/demo` | [`1.0.0`](https://www.npmjs.com/package/@acme/demo/v/1.0.0) | [`2.0.0`](https://www.npmjs.com/package/@acme/demo/v/2.0.0) |',
     ].join('\n'))
     expect(body).not.toContain('This PR was generated')
     expect(body).not.toContain('.changeset/ledger.yaml')
@@ -126,7 +126,9 @@ describe('release pull request body', () => {
     expect(body.indexOf('## 🚀 Features')).toBeLessThan(body.indexOf('## 🐞 Bug Fixes'))
     expect(body).toContain('<summary>🧰 Maintenance</summary>')
     expect(body).toContain('Thanks to @alice · @bob')
+    expect(body).toContain('https://www.npmjs.com/package/@acme/demo/v/2.0.0')
     expect(release).toContain('### 🚀 Features')
+    expect(release).toContain('[@acme/demo@2.0.0](https://www.npmjs.com/package/@acme/demo/v/2.0.0)')
     expect(release).not.toContain('## Packages')
     expect(release).toContain('View changes on GitHub')
   })


### PR DESCRIPTION
## Summary

- show package upgrade ranges as `From` → `To` in Release PRs
- link previous and target versions to their npm package pages
- link `package@version` entries in GitHub Releases
- skip npm links for private workspace packages

## Verification

- `pnpm build`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm tsd`
- `pnpm test` (68 files, 262 tests)

Existing dependency advisory warnings from `debug` and `micromatch` are unchanged.