### PR TITLE
fix(repoctl): defer npm links until publish

### DIFF
--- a/.changeset/release-npm-links-prepublish.md
+++ b/.changeset/release-npm-links-prepublish.md
@@ -1,0 +1,5 @@
+---
+"@icebreakers/monorepo": patch
+---
+
+避免在尚未发布的 Release PR 中把目标版本链接到 npm，仅为已存在的旧版本和已发布的 GitHub Release 版本提供 npm 链接。

--- a/packages/monorepo/src/commands/release/notes/render.ts
+++ b/packages/monorepo/src/commands/release/notes/render.ts
@@ -19,8 +19,8 @@ function formatReferenceLinks(entry: ReleaseNoteEntry, metadata: ReleaseBodyMeta
   return links.length ? ` ${links.join(' · ')}` : ''
 }
 
-function formatEntry(entry: ReleaseNoteEntry, metadata: ReleaseBodyMetadata) {
-  const packageLabel = entry.npmUrl
+function formatEntry(entry: ReleaseNoteEntry, metadata: ReleaseBodyMetadata, linkNpmVersion: boolean) {
+  const packageLabel = linkNpmVersion && entry.npmUrl
     ? `[${entry.packageName}@${entry.version}](${entry.npmUrl})`
     : `${entry.packageName}@${entry.version}`
   return `- **${packageLabel}**: ${entry.summary}${formatReferenceLinks(entry, metadata)}`
@@ -31,6 +31,7 @@ function formatCategoryEntries(
   category: ReleaseCategory,
   metadata: ReleaseBodyMetadata,
   headingLevel: 2 | 3,
+  linkNpmVersion: boolean,
 ) {
   const matching = entries.filter(entry => entry.category === category)
   if (!matching.length) {
@@ -39,7 +40,7 @@ function formatCategoryEntries(
   return [
     `${'#'.repeat(headingLevel)} ${categoryTitles[category]}`,
     '',
-    ...matching.map(entry => formatEntry(entry, metadata)),
+    ...matching.map(entry => formatEntry(entry, metadata, linkNpmVersion)),
   ]
 }
 
@@ -61,7 +62,7 @@ function formatVersion(version: string, npmUrl?: string) {
   return npmUrl ? `[\`${version}\`](${npmUrl})` : `\`${version}\``
 }
 
-function formatPackages(packages: ReleaseNoteDocument['packages']) {
+function formatPackages(packages: ReleaseNoteDocument['packages'], linkNpmVersion: boolean) {
   if (!packages.length) {
     return []
   }
@@ -72,7 +73,7 @@ function formatPackages(packages: ReleaseNoteDocument['packages']) {
     '| --- | --- | --- |',
     ...packages.map((pkg) => {
       const previous = pkg.previousVersion ? formatVersion(pkg.previousVersion, pkg.previousNpmUrl) : '—'
-      const current = formatVersion(pkg.version, pkg.npmUrl)
+      const current = formatVersion(pkg.version, linkNpmVersion ? pkg.npmUrl : undefined)
       return `| \`${pkg.name}\` | ${previous} | ${current} |`
     }),
   ]
@@ -84,18 +85,18 @@ export function renderReleasePullRequest(document: ReleaseNoteDocument, metadata
   const sections = ['# Release Notes', '', `> ${packageWord} updated · ${changeWord}`]
 
   for (const category of categoryOrder.filter(category => category !== 'maintenance')) {
-    const section = formatCategoryEntries(document.entries, category, metadata, 2)
+    const section = formatCategoryEntries(document.entries, category, metadata, 2, false)
     if (section.length) {
       sections.push('', '', ...section)
     }
   }
 
-  const maintenance = formatCategoryEntries(document.entries, 'maintenance', metadata, 2)
+  const maintenance = formatCategoryEntries(document.entries, 'maintenance', metadata, 2, false)
   if (maintenance.length) {
     sections.push('', '', '<details>', '<summary>🧰 Maintenance</summary>', '', ...maintenance.slice(2), '', '</details>')
   }
 
-  sections.push('', '', ...formatPackages(document.packages))
+  sections.push('', '', ...formatPackages(document.packages, false))
   sections.push('', '', ...formatContributors(document.contributors))
   return sections.join('\n').replace(/\n{3,}/g, '\n\n').trim()
 }
@@ -107,7 +108,7 @@ export function renderGitHubRelease(document: ReleaseNoteDocument, metadata: Rel
 
   const sections: string[] = []
   for (const category of categoryOrder) {
-    const section = formatCategoryEntries(document.entries, category, metadata, 3)
+    const section = formatCategoryEntries(document.entries, category, metadata, 3, true)
     if (section.length) {
       sections.push(...(sections.length ? ['', ...section] : section))
     }

--- a/packages/monorepo/test/commands/release-body.test.ts
+++ b/packages/monorepo/test/commands/release-body.test.ts
@@ -53,13 +53,13 @@ describe('release pull request body', () => {
       '',
       '## 🚀 Features',
       '',
-      '- **[@acme/demo@2.0.0](https://www.npmjs.com/package/@acme/demo/v/2.0.0)**: 增加新的发布能力。',
+      '- **@acme/demo@2.0.0**: 增加新的发布能力。',
       '',
       '## Packages',
       '',
       '| Package | From | To |',
       '| --- | --- | --- |',
-      '| `@acme/demo` | [`1.0.0`](https://www.npmjs.com/package/@acme/demo/v/1.0.0) | [`2.0.0`](https://www.npmjs.com/package/@acme/demo/v/2.0.0) |',
+      '| `@acme/demo` | [`1.0.0`](https://www.npmjs.com/package/@acme/demo/v/1.0.0) | `2.0.0` |',
     ].join('\n'))
     expect(body).not.toContain('This PR was generated')
     expect(body).not.toContain('.changeset/ledger.yaml')
@@ -126,7 +126,8 @@ describe('release pull request body', () => {
     expect(body.indexOf('## 🚀 Features')).toBeLessThan(body.indexOf('## 🐞 Bug Fixes'))
     expect(body).toContain('<summary>🧰 Maintenance</summary>')
     expect(body).toContain('Thanks to @alice · @bob')
-    expect(body).toContain('https://www.npmjs.com/package/@acme/demo/v/2.0.0')
+    expect(body).toContain('https://www.npmjs.com/package/@acme/demo/v/1.0.0')
+    expect(body).not.toContain('https://www.npmjs.com/package/@acme/demo/v/2.0.0')
     expect(release).toContain('### 🚀 Features')
     expect(release).toContain('[@acme/demo@2.0.0](https://www.npmjs.com/package/@acme/demo/v/2.0.0)')
     expect(release).not.toContain('## Packages')


### PR DESCRIPTION
## Summary

- keep the previous `From` version linked to npm in Release PRs
- leave the not-yet-published `To` version as plain text
- keep current-version npm links in GitHub Releases after publication

## Verification

- release tests (30 passed)
- monorepo typecheck
- lint

The existing dependency advisory warnings are unchanged.