### PR TITLE
feat(repoctl): summarize published packages

### DIFF
--- a/.changeset/release-publish-summary.md
+++ b/.changeset/release-publish-summary.md
@@ -1,0 +1,5 @@
+---
+"@icebreakers/monorepo": patch
+---
+
+在 Release CI 结束时汇总输出成功发布的包名与版本，便于直接确认本次发布结果。

--- a/packages/monorepo/src/cli/commands/release.ts
+++ b/packages/monorepo/src/cli/commands/release.ts
@@ -29,7 +29,6 @@ export function registerReleaseCommands(program: Command, cwd: string) {
           ...(opts.package ? { packageName: opts.package } : {}),
           ...(opts.version ? { packageVersion: opts.version } : {}),
         })
-        logger.success('release CI finished!')
       })
     })
 

--- a/packages/monorepo/src/commands/release/ci.ts
+++ b/packages/monorepo/src/commands/release/ci.ts
@@ -1,6 +1,7 @@
 import type { GitHubOperations } from './github'
 import type { PublishedPackage, ReleaseCiOptions, ReleaseMode, ReleaseOptions } from './types'
 import { spawnSync } from 'node:child_process'
+import { logger } from '../../core/logger'
 import { buildReleaseNoteDocument, readPendingIntentCommits, readWorkspaceVersions, renderGitHubRelease, renderReleasePullRequest } from './body'
 import { ReleaseCommandError } from './errors'
 import { GitHubClient } from './github'
@@ -37,8 +38,18 @@ function resolveTarget(options: ReleaseOptions) {
   return getReleaseEnv(options)['GITHUB_SHA']?.trim() || capture('git', ['rev-parse', 'HEAD'], options)
 }
 
+function formatPublishedPackageSummary(packages: PublishedPackage[]) {
+  return [
+    'Published packages:',
+    ...(packages.length
+      ? packages.map(pkg => `  - ${pkg.name}@${pkg.version}`)
+      : ['  (none)']),
+  ].join('\n')
+}
+
 async function publishMetadata(packages: PublishedPackage[], options: ReleaseCiOptions, prerelease = false) {
   if (!packages.length) {
+    logger.success(formatPublishedPackageSummary(packages))
     return
   }
   const github = resolveGitHub(options)
@@ -76,6 +87,7 @@ async function publishMetadata(packages: PublishedPackage[], options: ReleaseCiO
     run('git', ['push', 'origin', `refs/tags/${tag}`], options)
     await github.ensureRelease({ tag, target, prerelease, name: tag, body })
   }
+  logger.success(formatPublishedPackageSummary(packages))
 }
 
 async function createReleasePullRequest(options: ReleaseCiOptions) {

--- a/packages/monorepo/test/commands/release.test.ts
+++ b/packages/monorepo/test/commands/release.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os'
 import path from 'pathe'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { enterPrerelease, exitPrerelease, parsePublishSummary, prepareStable, publishStable, releaseCi, releasePrerelease } from '@/commands/release'
+import { logger } from '@/core/logger'
 
 interface SpawnCall {
   command: string
@@ -65,6 +66,7 @@ function createSpawnMock(options: { diffStatus?: number } = {}) {
 }
 
 afterEach(async () => {
+  vi.restoreAllMocks()
   await Promise.all(tempRoots.splice(0).map(root => rm(root, { force: true, recursive: true })))
 })
 
@@ -267,6 +269,7 @@ describe('release commands', () => {
       ensureTag: vi.fn(),
       ensureRelease: vi.fn(),
     }
+    const success = vi.spyOn(logger, 'success').mockImplementation(() => undefined)
 
     await releaseCi({
       mode: 'publish',
@@ -282,6 +285,7 @@ describe('release commands', () => {
       name: 'repoctl@1.0.0',
       body: expect.stringContaining('### 🐞 Bug Fixes'),
     }))
+    expect(success).toHaveBeenCalledWith('Published packages:\n  - repoctl@1.0.0')
   })
 
   it('parses pnpm publish summaries for release metadata', () => {


### PR DESCRIPTION
## Summary

- Print a final `Published packages` summary after stable, prerelease, and recovery publishing.
- Derive each line from the normalized publish summary as `package@version`.
- Keep empty publishes explicit with `(none)`.
- Add a Chinese changeset for `@icebreakers/monorepo`.

## Verification

- `pnpm build`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm tsd`
- `CI=1 pnpm test`

The local-only asset snapshot test still reflects the existing `origin/main` ledger asset baseline; CI skips that non-CI scenario.