### PR TITLE
fix(ci): synchronize Wrangler types in Renovate PRs

### DIFF
--- a/.changeset/clean-generated-ci.md
+++ b/.changeset/clean-generated-ci.md
@@ -1,0 +1,5 @@
+---
+"@icebreakers/monorepo-templates": patch
+---
+
+避免生成的仓库继承 repoctl 源仓库专用的 Worker 类型同步 CI 与 Renovate 配置。

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,32 @@ permissions:
   contents: read
 
 jobs:
+  generated-assets:
+    name: Generated Assets
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Check generated Worker types
+        run: pnpm cf-typegen:check
+
   build:
     name: Build and Test
+    needs: generated-assets
     timeout-minutes: 15
     strategy:
       fail-fast: false
@@ -71,3 +95,18 @@ jobs:
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  ci:
+    name: CI
+    if: ${{ always() }}
+    needs: [generated-assets, build]
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Verify required jobs
+        env:
+          BUILD_RESULT: ${{ needs.build.result }}
+          GENERATED_ASSETS_RESULT: ${{ needs.generated-assets.result }}
+        run: |
+          test "$GENERATED_ASSETS_RESULT" = "success"
+          test "$BUILD_RESULT" = "success"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,8 @@ When splitting code, do not create suffix-based sibling files such as `xxx.confi
 All generated code must pass ESLint checks, and all generated style files must pass Stylelint checks.
 Generated Vue files or other SFC files that include style blocks are also required to pass Stylelint checks.
 
+When manually updating a Renovate pull request, fetch its latest remote head before making changes. If Renovate updates the branch while work is in progress, rebase the local fix onto the newly fetched pull request head and push normally. Never force-push a Renovate-managed branch.
+
 ## Testing Guidelines
 
 Vitest powers unit tests located in `test/*.test.ts`. Mirror existing naming by matching the unit under test (`monorepo` utilities map to `packages/monorepo/test/*.test.ts`). Aim for meaningful assertions rather than snapshot defaults, and add coverage checks with `pnpm test -- --coverage`, which writes reports to `coverage/`. When introducing new public APIs, include integration-style tests in the relevant app workspace. AI-assisted validation must run a full test matrix when available, including unit, integration, and E2E tests.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,8 +27,6 @@ When splitting code, do not create suffix-based sibling files such as `xxx.confi
 All generated code must pass ESLint checks, and all generated style files must pass Stylelint checks.
 Generated Vue files or other SFC files that include style blocks are also required to pass Stylelint checks.
 
-When manually updating a Renovate pull request, fetch its latest remote head before making changes. If Renovate updates the branch while work is in progress, rebase the local fix onto the newly fetched pull request head and push normally. Never force-push a Renovate-managed branch.
-
 ## Testing Guidelines
 
 Vitest powers unit tests located in `test/*.test.ts`. Mirror existing naming by matching the unit under test (`monorepo` utilities map to `packages/monorepo/test/*.test.ts`). Aim for meaningful assertions rather than snapshot defaults, and add coverage checks with `pnpm test -- --coverage`, which writes reports to `coverage/`. When introducing new public APIs, include integration-style tests in the relevant app workspace. AI-assisted validation must run a full test matrix when available, including unit, integration, and E2E tests.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,4 +25,6 @@ Changes to publishable packages require a pnpm change intent created with `pnpm 
 
 When changing templates or managed root assets, update their source first and refresh packaged copies with `pnpm --filter @icebreakers/monorepo-templates sync:assets`.
 
+Before manually updating a Renovate pull request, fetch its latest remote head. If Renovate updates the branch while you are working, fetch again, rebase your local changes onto the latest pull request head, and push normally. Never force-push a Renovate-managed branch.
+
 Report bugs at https://github.com/sonofmagic/repoctl/issues and use discussions for design questions that do not yet have a concrete implementation.

--- a/CONTRIBUTING.zh-CN.md
+++ b/CONTRIBUTING.zh-CN.md
@@ -25,4 +25,6 @@ pnpm test
 
 修改模板或受管根资产时，先修改源码，再运行 `pnpm --filter @icebreakers/monorepo-templates sync:assets` 刷新随包副本。
 
+人工更新 Renovate Pull Request 前，必须先获取其最新远端 head。如果操作期间 Renovate 更新了分支，请重新获取远端变更，将本地改动 rebase 到最新的 Pull Request head，再进行普通 push。禁止对 Renovate 管理的分支执行 force push。
+
 缺陷请提交到 https://github.com/sonofmagic/repoctl/issues；尚未形成具体实现的设计问题请使用 Discussions。

--- a/packages/create-repoctl/src/source-npm.test.ts
+++ b/packages/create-repoctl/src/source-npm.test.ts
@@ -15,10 +15,12 @@ describe('scaffoldFromNpm', () => {
       await updateRootPackageJson(targetDir, 'demo-repo')
       await updateRootTsconfigReferences(targetDir)
 
-      const [rootVitestConfig, rootTsconfig, releaseWorkflow] = await Promise.all([
+      const [rootVitestConfig, rootTsconfig, releaseWorkflow, ciWorkflow, renovateConfig] = await Promise.all([
         readFile(path.join(targetDir, 'vitest.config.ts'), 'utf8'),
         readFile(path.join(targetDir, 'tsconfig.json'), 'utf8'),
         readFile(path.join(targetDir, '.github/workflows/release.yml'), 'utf8'),
+        readFile(path.join(targetDir, '.github/workflows/ci.yml'), 'utf8'),
+        readFile(path.join(targetDir, 'renovate.json'), 'utf8'),
       ])
       const parsedTsconfig = JSON.parse(rootTsconfig) as {
         references?: Array<{ path: string }>
@@ -28,6 +30,11 @@ describe('scaffoldFromNpm', () => {
       expect(rootVitestConfig).not.toContain('tooling/load-tooling-module.mjs')
       expect(releaseWorkflow).not.toContain('Build Release Tooling')
       expect(releaseWorkflow).not.toContain('pnpm run tooling:build')
+      expect(ciWorkflow).not.toContain('generated-assets')
+      expect(ciWorkflow).not.toContain('Check generated Worker types')
+      expect(renovateConfig).not.toContain('rebaseWhen')
+      expect(renovateConfig).not.toContain('postUpgradeTasks')
+      expect(renovateConfig).not.toContain('pnpm cf-typegen')
       expect(parsedTsconfig.references).toEqual([
         { path: './apps/cli' },
         { path: './packages/tsdown' },

--- a/packages/monorepo-templates/src/prepare.test.ts
+++ b/packages/monorepo-templates/src/prepare.test.ts
@@ -1,6 +1,96 @@
 import { describe, expect, it } from 'vitest'
 import YAML from 'yaml'
 import { removeSourceRepoReleaseToolingBuildStepContent, sanitizePublishedWorkspaceContent } from './prepare'
+import { sanitizePublishedCiWorkflowContent, sanitizePublishedRenovateContent } from './prepare/published-config'
+
+describe('sanitizePublishedCiWorkflowContent', () => {
+  it('removes source-only generated asset jobs while preserving the build job', () => {
+    const content = [
+      'name: CI',
+      '',
+      'jobs:',
+      '  generated-assets:',
+      '    name: Generated Assets',
+      '    steps:',
+      '      - run: pnpm cf-typegen:check',
+      '  build:',
+      '    name: Build and Test',
+      '    needs: generated-assets',
+      '    strategy:',
+      '      fail-fast: false',
+      '  ci:',
+      '    name: CI',
+      '    needs: [generated-assets, build]',
+      '    steps:',
+      '      - run: test "$GENERATED_ASSETS_RESULT" = "success"',
+      '',
+    ].join('\n')
+
+    const workflow = YAML.parse(sanitizePublishedCiWorkflowContent(content)) as {
+      jobs: Record<string, { needs?: string | string[], strategy?: unknown }>
+    }
+
+    expect(workflow.jobs['generated-assets']).toBeUndefined()
+    expect(workflow.jobs['ci']).toBeUndefined()
+    expect(workflow.jobs['build']).toEqual({
+      name: 'Build and Test',
+      strategy: { 'fail-fast': false },
+    })
+  })
+
+  it('leaves workflows without the source-only job unchanged', () => {
+    const content = 'jobs:\n  build:\n    name: Build and Test\n'
+
+    expect(sanitizePublishedCiWorkflowContent(content)).toBe(content)
+  })
+})
+
+describe('sanitizePublishedRenovateContent', () => {
+  it('removes source-only tasks from the Cloudflare tooling rule', () => {
+    const content = `${JSON.stringify({
+      extends: ['config:recommended'],
+      packageRules: [
+        {
+          groupSlug: 'all-non-major',
+          rebaseWhen: 'behind-base-branch',
+        },
+        {
+          matchPackageNames: ['wrangler', '@cloudflare/vite-plugin'],
+          groupName: 'Cloudflare Workers tooling',
+          groupSlug: 'cloudflare-workers-tooling',
+          rebaseWhen: 'conflicted',
+          postUpgradeTasks: {
+            commands: ['pnpm cf-typegen'],
+            fileFilters: ['templates/client/worker-configuration.d.ts'],
+            executionMode: 'branch',
+          },
+        },
+      ],
+    }, null, 2)}\n`
+
+    const config = JSON.parse(sanitizePublishedRenovateContent(content)) as {
+      extends: string[]
+      packageRules: Array<Record<string, unknown>>
+    }
+
+    expect(config.extends).toEqual(['config:recommended'])
+    expect(config.packageRules[0]).toEqual({
+      groupSlug: 'all-non-major',
+      rebaseWhen: 'behind-base-branch',
+    })
+    expect(config.packageRules[1]).toEqual({
+      matchPackageNames: ['wrangler', '@cloudflare/vite-plugin'],
+      groupName: 'Cloudflare Workers tooling',
+      groupSlug: 'cloudflare-workers-tooling',
+    })
+  })
+
+  it('leaves Renovate configs without source-only tasks unchanged', () => {
+    const content = '{\n  "packageRules": []\n}\n'
+
+    expect(sanitizePublishedRenovateContent(content)).toBe(content)
+  })
+})
 
 describe('sanitizePublishedWorkspaceContent', () => {
   it('removes source repository package identities and preserves generic versioning settings', () => {

--- a/packages/monorepo-templates/src/prepare.ts
+++ b/packages/monorepo-templates/src/prepare.ts
@@ -5,6 +5,7 @@ import YAML from 'yaml'
 import { assetTargets } from '../assets-data.mjs'
 import { templateChoices } from '../template-data.mjs'
 import { assetsDir, packageDir, templatesDir } from './paths'
+import { sanitizePublishedCiWorkflowContent, sanitizePublishedRenovateContent } from './prepare/published-config'
 import { toPublishGitignorePath } from './utils/gitignore'
 import { shouldSkipTemplatePath } from './utils/template-filter'
 
@@ -197,17 +198,31 @@ async function removePublishedReleaseState() {
   await fs.rm(path.join(assetsDir, '.changeset', 'ledger.yaml'), { force: true })
 }
 
-async function removeSourceRepoReleaseToolingBuildStep() {
-  const releaseWorkflowPath = path.join(assetsDir, '.github/workflows/release.yml')
-  if (!await pathExists(releaseWorkflowPath)) {
+async function transformPublishedAsset(relativePath: string, transform: (content: string) => string) {
+  const assetPath = path.join(assetsDir, relativePath)
+  if (!await pathExists(assetPath)) {
     return
   }
 
-  const content = await fs.readFile(releaseWorkflowPath, 'utf8')
-  const nextContent = removeSourceRepoReleaseToolingBuildStepContent(content)
+  const content = await fs.readFile(assetPath, 'utf8')
+  const nextContent = transform(content)
   if (nextContent !== content) {
-    await fs.writeFile(releaseWorkflowPath, nextContent, 'utf8')
+    await fs.writeFile(assetPath, nextContent, 'utf8')
   }
+}
+
+async function sanitizePublishedRepositoryConfig() {
+  await Promise.all([
+    transformPublishedAsset('.github/workflows/ci.yml', sanitizePublishedCiWorkflowContent),
+    transformPublishedAsset('renovate.json', sanitizePublishedRenovateContent),
+  ])
+}
+
+async function removeSourceRepoReleaseToolingBuildStep() {
+  await transformPublishedAsset(
+    '.github/workflows/release.yml',
+    removeSourceRepoReleaseToolingBuildStepContent,
+  )
 }
 
 async function copyTemplates(repoRoot: string, overwriteExisting: boolean) {
@@ -232,6 +247,7 @@ export async function prepareAssets(options: PrepareAssetsOptions = {}) {
   await resetDir(assetsDir, overwriteExisting)
   await resetDir(templatesDir, overwriteExisting)
   await copyAssets(repoRoot, overwriteExisting)
+  await sanitizePublishedRepositoryConfig()
   await sanitizePublishedWorkspace()
   await removePublishedReleaseState()
   await writePublishedToolingConfigs()

--- a/packages/monorepo-templates/src/prepare/published-config.ts
+++ b/packages/monorepo-templates/src/prepare/published-config.ts
@@ -1,0 +1,94 @@
+import YAML from 'yaml'
+
+type UnknownRecord = Record<string, unknown>
+
+interface WorkflowJob extends UnknownRecord {
+  needs?: string | string[]
+}
+
+interface WorkflowConfig extends UnknownRecord {
+  jobs?: Record<string, WorkflowJob>
+}
+
+interface RenovateConfig extends UnknownRecord {
+  packageRules?: UnknownRecord[]
+}
+
+const generatedAssetsJob = 'generated-assets'
+const cloudflareWorkersToolingGroup = 'cloudflare-workers-tooling'
+
+function isRecord(value: unknown): value is UnknownRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function referencesJob(needs: unknown, jobName: string) {
+  return needs === jobName || (Array.isArray(needs) && needs.includes(jobName))
+}
+
+function removeJobDependency(needs: string | string[], jobName: string) {
+  if (typeof needs === 'string') {
+    return needs === jobName ? undefined : needs
+  }
+  const remaining = needs.filter(name => name !== jobName)
+  return remaining.length > 0 ? remaining : undefined
+}
+
+export function sanitizePublishedCiWorkflowContent(content: string) {
+  const document = YAML.parseDocument(content)
+  if (document.errors.length > 0) {
+    throw document.errors[0]
+  }
+
+  const workflow = document.toJS() as WorkflowConfig | null
+  const jobs = workflow?.jobs
+  if (!isRecord(jobs) || !isRecord(jobs[generatedAssetsJob])) {
+    return content
+  }
+
+  document.deleteIn(['jobs', generatedAssetsJob])
+
+  const build = jobs['build']
+  if (isRecord(build) && referencesJob(build.needs, generatedAssetsJob)) {
+    const nextNeeds = removeJobDependency(build.needs as string | string[], generatedAssetsJob)
+    if (nextNeeds === undefined) {
+      document.deleteIn(['jobs', 'build', 'needs'])
+    }
+    else {
+      document.setIn(['jobs', 'build', 'needs'], nextNeeds)
+    }
+  }
+
+  const aggregate = jobs['ci']
+  if (isRecord(aggregate) && referencesJob(aggregate.needs, generatedAssetsJob)) {
+    document.deleteIn(['jobs', 'ci'])
+  }
+
+  return document
+    .toString({ flowCollectionPadding: false })
+    .replace(/[ \t]+$/gm, '')
+    .replace(/(^|\n)(jobs:\n)\n(?= {2}\S)/, '$1$2')
+}
+
+export function sanitizePublishedRenovateContent(content: string) {
+  const config = JSON.parse(content) as RenovateConfig
+  if (!Array.isArray(config.packageRules)) {
+    return content
+  }
+
+  let changed = false
+  for (const rule of config.packageRules) {
+    if (!isRecord(rule) || rule['groupSlug'] !== cloudflareWorkersToolingGroup) {
+      continue
+    }
+    if ('rebaseWhen' in rule) {
+      delete rule['rebaseWhen']
+      changed = true
+    }
+    if ('postUpgradeTasks' in rule) {
+      delete rule['postUpgradeTasks']
+      changed = true
+    }
+  }
+
+  return changed ? `${JSON.stringify(config, null, 2)}\n` : content
+}

--- a/packages/monorepo/test/commands/template-quality.test.ts
+++ b/packages/monorepo/test/commands/template-quality.test.ts
@@ -64,6 +64,19 @@ describe('generated template quality', () => {
     expect(content).not.toContain('pnpm run tooling:build')
   })
 
+  it('does not ship source-repo-only Worker type synchronization', async () => {
+    const [ciWorkflow, renovateConfig] = await Promise.all([
+      fs.readFile(`${assetsDir}/.github/workflows/ci.yml`, 'utf8'),
+      fs.readFile(`${assetsDir}/renovate.json`, 'utf8'),
+    ])
+
+    expect(ciWorkflow).not.toContain('generated-assets')
+    expect(ciWorkflow).not.toContain('Check generated Worker types')
+    expect(renovateConfig).not.toContain('rebaseWhen')
+    expect(renovateConfig).not.toContain('postUpgradeTasks')
+    expect(renovateConfig).not.toContain('pnpm cf-typegen')
+  })
+
   it('does not ship stale TypeScript deprecation suppressions', async () => {
     const files = [
       ...await collectTextFiles(assetsDir),

--- a/renovate.json
+++ b/renovate.json
@@ -32,7 +32,18 @@
         "@cloudflare/vite-plugin"
       ],
       "groupName": "Cloudflare Workers tooling",
-      "groupSlug": "cloudflare-workers-tooling"
+      "groupSlug": "cloudflare-workers-tooling",
+      "rebaseWhen": "conflicted",
+      "postUpgradeTasks": {
+        "commands": [
+          "pnpm cf-typegen"
+        ],
+        "fileFilters": [
+          "templates/client/worker-configuration.d.ts",
+          "templates/server/worker-configuration.d.ts"
+        ],
+        "executionMode": "branch"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary

- regenerate committed Worker runtime types in Cloudflare tooling Renovate PRs
- fail fast on stale generated assets before running the cross-platform matrix
- publish a stable `CI` aggregate check for the main branch ruleset
- document safe manual updates to Renovate-managed branches

## Testing

- `pnpm cf-typegen` (idempotent; no generated diff)
- Renovate 44.43.1 config validation
- `pnpm build`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm tsd`
- `pnpm test` (73 files, 314 tests)

## Rollout gate

Keep this PR in draft until Mend-hosted Renovate confirms that the exact `pnpm cf-typegen` post-upgrade command is allowed. After merge and a successful `CI` status, add the non-strict `main-pr-ci` ruleset requiring the stable `CI` check.