### PR TITLE
fix(monorepo): resolve packaged tsconfig export

### DIFF
--- a/.changeset/breezy-foxes-stare.md
+++ b/.changeset/breezy-foxes-stare.md
@@ -1,0 +1,6 @@
+---
+"@icebreakers/monorepo": patch
+"repoctl": patch
+---
+
+Resolve the bundled TypeScript baseline through package exports so repoctl tooling works after installation.

--- a/packages/monorepo/src/tooling/index.ts
+++ b/packages/monorepo/src/tooling/index.ts
@@ -176,7 +176,7 @@ const windowsPathSeparatorPattern = /\\/g
 const relativeCurrentDirPattern = /^\.\//
 const globTokenPattern = /[*?[{]/
 const trailingSlashPattern = /\/+$/
-const monorepoTsconfigPath = fileURLToPath(new URL('../../tsconfig.base.json', import.meta.url))
+const monorepoTsconfigPath = fileURLToPath(import.meta.resolve('@icebreakers/monorepo/tsconfig'))
 
 function escapeForShell(value: string) {
   return `'${value.replaceAll('\'', '\'\\\'\'')}'`

--- a/scripts/smoke-packaged-doctor.mjs
+++ b/scripts/smoke-packaged-doctor.mjs
@@ -56,6 +56,9 @@ try {
     '  - apps/*',
     '  - packages/*',
     '  - examples/*',
+    'overrides:',
+    `  '@icebreakers/monorepo': ${JSON.stringify(`file:${monorepoTarball}`)}`,
+    `  '@icebreakers/monorepo-templates': ${JSON.stringify(`file:${templatesTarball}`)}`,
     'versioning:',
     '  changelog:',
     '    storage: repository',
@@ -74,6 +77,16 @@ try {
   const manifest = JSON.parse(run(['exec', 'node', '-p', 'JSON.stringify(require("./package.json"))'], workspaceDir, 'pipe'))
   if (manifest.dependencies?.vitest || manifest.devDependencies?.vitest) {
     throw new Error('the smoke workspace must not declare Vitest')
+  }
+  const tsconfig = JSON.parse(run([
+    'exec',
+    'node',
+    '--input-type=module',
+    '--eval',
+    'import { createMonorepoTsconfig } from \'repoctl/tooling\'; process.stdout.write(JSON.stringify(createMonorepoTsconfig()))',
+  ], workspaceDir, 'pipe'))
+  if (tsconfig.compilerOptions?.target !== 'ESNext') {
+    throw new Error('the packaged tooling entry must load the bundled tsconfig')
   }
   run(['exec', 'repoctl', 'doctor', '--strict'], workspaceDir)
 }


### PR DESCRIPTION
## Summary

Fix `createMonorepoTsconfig()` failing after `@icebreakers/monorepo` is bundled and installed. The source-relative `../../tsconfig.base.json` path changes meaning when tsdown emits the tooling chunk under `dist/`, causing repoctl 5.4.2 to read a file outside the package.

## Changes

- Resolve the bundled TypeScript baseline through the package self-reference export, `@icebreakers/monorepo/tsconfig`.
- Make the packaged-doctor smoke workspace override transitive dependencies to the locally packed tarballs.
- Exercise `repoctl/tooling#createMonorepoTsconfig()` from the installed tarballs and verify the expected baseline.
- Record patch release intents for `@icebreakers/monorepo` and `repoctl`.

## Testing

- `pnpm build`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm tsd`
- `pnpm test` (73 files, 314 tests)
- `pnpm test:packaged-doctor`
